### PR TITLE
Fix incorrect parameter name in `.map()` example

### DIFF
--- a/docs/concepts/tasks.md
+++ b/docs/concepts/tasks.md
@@ -270,7 +270,7 @@ The simplest Prefect map takes a tasks and applies it to each element of its inp
 from prefect import flow, task
 
 @task
-def print_nums(n):
+def print_nums(nums):
     for n in nums:
         print(n)
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to Prefect! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Confirm that you've done common tasks so we can give a timely review.

Happy engineering!
-->

This PR provides a small fix for the first example of the [`.map()`](https://docs.prefect.io/concepts/tasks/#map) function in the `Task` concepts. In the original example, the parameter `n` got mixed up with `nums`, such that `nums` is not defined.

<!-- Include an overview here -->

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->

Running the example raises a `NameError`:

```python
  File "python3.9/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "<stdin>", line 3, in print_nums
NameError: name 'nums' is not defined
```


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "closes `<link to issue>`"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] This pull request includes a `fix`, `feature`, `enhancement`, `docs`, `collections`, or `maintenance` label categorizing the change.
  <!--  If you do not have permission to add a label, a maintainer will add one for you and check this box. -->
